### PR TITLE
Fix readme typo; fix retrieval tensor not serializable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Building the dense index can be expensive for GPU memory (we use 80GB GPUs for t
 If you find this step to be too expensive, you can also download it using:
 ```bash
 wget https://huggingface.co/datasets/princeton-nlp/gtr-t5-xxl-wikipedia-psgs_w100-index/resolve/main/gtr_wikipedia_index.pkl
-export GTR=$PWD/gtr_wikipedia_index.pkl
+export GTR_EMB=$PWD/gtr_wikipedia_index.pkl
 ```
 
 To reproduce the DPR retrieval, we refer the DPR [repo](https://github.com/facebookresearch/DPR), which we used the original DPR checkpoint trained on NQ.

--- a/retrieval.py
+++ b/retrieval.py
@@ -95,7 +95,7 @@ def gtr_wiki_retrieval(data):
         ret = []
         for i in range(idx.size(0)):
             title, text = docs[idx[i].item()].split("\n")
-            ret.append({"id": str(idx[i].item()+1),"title": title, "text": text, "score": score[i]})
+            ret.append({"id": str(idx[i].item()+1),"title": title, "text": text, "score": score[i].item()})
         data[qi]["docs"] = ret
         q = q.to("cpu")
 


### PR DESCRIPTION
1. Fix `README.md`: change the `$GTR` to `$GTR_EMB`
2. Fix the `TypeError: Object of type Tensor is not JSON serializable` error when writing the score to the json file in `retrieval.py`